### PR TITLE
Make data urls not try to use CORS

### DIFF
--- a/src/GLImage.js
+++ b/src/GLImage.js
@@ -2,7 +2,9 @@ const createTexture = require("gl-texture2d");
 
 function loadImage (src, success, failure) {
   var img = new window.Image();
-  img.crossOrigin = true;
+  if (src.slice(0,5) !== "data:") {
+    img.crossOrigin = true;
+  }
   img.onload = function () {
     success(img);
   };


### PR DESCRIPTION
This is needed on Safari, because it fails to load images from data urls with a CORS error.

Use case is using a canvas to crop/resize an image and then export it with `toDataURL`, and use that in webgl.  This change allows that to work.
